### PR TITLE
fix(Named-Pipe-Server/new/Server-Options/Pipe-Mode): switch from messages to bytes

### DIFF
--- a/src/named_pipe_server.rs
+++ b/src/named_pipe_server.rs
@@ -31,13 +31,7 @@ impl NamedPipeServerManager {
     /// Create an object of the server manager
     /// * `name` The name of the Named Pipe this server has to bind to
     pub fn new(name: impl Into<String>) -> Self {
-        use tokio::net::windows::named_pipe::PipeMode;
-        Self::with_options(
-            name.into(),
-            named_pipe::ServerOptions::new()
-                .pipe_mode(PipeMode::Message)
-                .to_owned(),
-        )
+        Self::with_options(name.into(), named_pipe::ServerOptions::new())
     }
 
     /// Create an object of the server manager


### PR DESCRIPTION
Needed as PipeMode::Messages comes with additional issues such as error code 234 which isn't actually an error but causes issues internally. Its far easier to not use it and not face issues. Theres a chance its not the performance improvement I imagined it to b anyways

Works as PipeMode::Byte is the default Mode in Windows.